### PR TITLE
fix python3 issue with basic auth middleware

### DIFF
--- a/aldryn_sso/middleware.py
+++ b/aldryn_sso/middleware.py
@@ -5,6 +5,7 @@ Access Control Middleware
 import logging
 import re
 import sys
+import base64
 
 from django.conf import settings
 from django.core.urlresolvers import NoReverseMatch, reverse
@@ -143,7 +144,7 @@ class BasicAuthAccessControlMiddleware(BaseAccessControlMiddleware):
             (authmeth, auth) = authentication.split(' ', 1)
             if 'basic' != authmeth.lower():
                 return self.unauthed(request)
-            auth = auth.strip().decode('base64')
+            auth = base64.b64decode(auth.strip())
             username, password = auth.split(':', 1)
             if (
                 username == settings.ALDRYN_SSO_BASICAUTH_USER and


### PR DESCRIPTION
fix python3 issue with basic auth middleware

fixes ``AttributeError`` here https://github.com/aldryn/aldryn-sso/commit/5cf371d46d394cf9e86994636e9abfd199791030#diff-e763f85e34be76d04c578d355bd34b11R146

Fixed version
=============

Python 2
--------

```python
# Python 2.7.10
>>> import base64
>>> s = 'dGVzdDp0ZXN0'
>>> s.decode('base64')
'test:test'
>>> base64.b64decode(s)
'test:test'
>>> base64.b64decode(s) == s.decode('base64')
True
```

Python 3
--------

```python
# Python 3.5.1
>>> import base64
>>> s = 'dGVzdDp0ZXN0'
>>> s.decode('base64')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
>>> base64.b64decode(s)
b'test:test'
```