### PR TITLE
Don't redirect to / after sharing token init

### DIFF
--- a/aldryn_sso/middleware.py
+++ b/aldryn_sso/middleware.py
@@ -82,7 +82,7 @@ class BaseAccessControlMiddleware(object):
             token = request.GET.get(settings.SHARING_VIEW_ONLY_TOKEN_KEY_NAME, None)
             if secret_token == token:
                 request.session[settings.SHARING_VIEW_ONLY_TOKEN_KEY_NAME] = token
-                return HttpResponseRedirect('/')
+                return HttpResponseRedirect(request.get_full_path())
 
 
 class AccessControlMiddleware(BaseAccessControlMiddleware):


### PR DESCRIPTION
Previously all requests where redirected to / after initialising a
session with the sharing token. With this change it will redirect
to the same path that was originally opened.